### PR TITLE
Try enabling Fortran on MacOS X

### DIFF
--- a/recipe/TEST_FILES_LICENSE.md
+++ b/recipe/TEST_FILES_LICENSE.md
@@ -1,0 +1,39 @@
+
+				  COPYRIGHT
+
+The following is a notice of limited availability of the code, and disclaimer
+which must be included in the prologue of the code and in all source listings
+of the code.
+
+Copyright Notice
+ + 2002 University of Chicago
+
+Permission is hereby granted to use, reproduce, prepare derivative works, and
+to redistribute to others.  This software was authored by:
+
+Mathematics and Computer Science Division
+Argonne National Laboratory, Argonne IL 60439
+
+(and)
+
+Department of Computer Science
+University of Illinois at Urbana-Champaign
+
+
+			      GOVERNMENT LICENSE
+
+Portions of this material resulted from work developed under a U.S.
+Government Contract and are subject to the following license: the Government
+is granted for itself and others acting on its behalf a paid-up, nonexclusive,
+irrevocable worldwide license in this computer software to reproduce, prepare
+derivative works, and perform publicly and display publicly.
+
+				  DISCLAIMER
+
+This computer code material was prepared, in part, as an account of work
+sponsored by an agency of the United States Government.  Neither the United
+States, nor the University of Chicago, nor any of their employees, makes any
+warranty express or implied, or assumes any legal liability or responsibility
+for the accuracy, completeness, or usefulness of any information, apparatus,
+product, or process disclosed, or represents that its use would not infringe
+privately owned rights.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-if [[ $(uname) == Linux ]]; then
-  # FIXME: This is a terrible workaround.
-  # Ideally we should fix the information the .la files.
-  rm -rf $PREFIX/lib/libquadmath.la
-  rm -rf $PREFIX/lib/libgfortran.la
-fi
-
 if [ "$(uname)" == "Darwin" ]
 then
     export DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,14 +5,18 @@ if [[ $(uname) == Linux ]]; then
   # Ideally we should fix the information the .la files.
   rm -rf $PREFIX/lib/libquadmath.la
   rm -rf $PREFIX/lib/libgfortran.la
-  OPTS="--enable-fortran=yes"
-elif [[ $(uname) == Darwin ]]; then
-  OPTS="--enable-fortran=no"
 fi
+
+if [ "$(uname)" == "Darwin" ]
+then
+    export DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib
+fi
+
+export LIBRARY_PATH="${PREFIX}/lib"
 
 ./configure --prefix=$PREFIX \
             --enable-shared \
-            $OPTS
+            --enable-fortran=yes
 
 make
 make testing

--- a/recipe/hellow.c
+++ b/recipe/hellow.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+
+int main( int argc, char *argv[] )
+{
+    int rank;
+    int size;
+    
+    MPI_Init( 0, 0 );
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    printf( "Hello world from process %d of %d\n", rank, size );
+    MPI_Finalize();
+    return 0;
+}

--- a/recipe/hellow.f
+++ b/recipe/hellow.f
@@ -1,0 +1,17 @@
+c  (C) 2008 by Argonne National Laboratory.
+c      See COPYRIGHT in top-level directory.
+
+      program main
+
+      include 'mpif.h'
+
+      integer ierr, myid, numprocs
+
+      call MPI_INIT( ierr )
+      call MPI_COMM_RANK( MPI_COMM_WORLD, myid, ierr )
+      call MPI_COMM_SIZE( MPI_COMM_WORLD, numprocs, ierr )
+      print *, "Process ", myid, " of ", numprocs, " is alive"
+
+      call MPI_FINALIZE(rc)
+      stop
+      end

--- a/recipe/hellow.f90
+++ b/recipe/hellow.f90
@@ -1,0 +1,19 @@
+!  (C) 2008 by Argonne National Laboratory.
+!      See COPYRIGHT in top-level directory.
+
+program main
+
+  use mpi
+  
+  implicit none
+
+  integer :: ierr, myid, numprocs, rc
+
+  call mpi_init(ierr)
+  call mpi_comm_rank(MPI_COMM_WORLD, myid, ierr)
+  call mpi_comm_size(MPI_COMM_WORLD, numprocs, ierr)
+  print *, "Process ", myid, " of ", numprocs, " is alive"
+
+  call mpi_finalize(rc)
+
+end program main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,23 +10,21 @@ source:
     sha256: 0778679a6b693d7b7caff37ff9d2856dc2bfc51318bf8373859bfa74253da3dc
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
 
 requirements:
     build:
-        - toolchain
         - gcc
         - perl
-        - gcc  # [osx]
-        - libgfortran  # [linux]
     run:
-        - libgfortran  # [not win]
+        - libgfortran  # [osx]
+        - libgcc  # [linux]
 
 test:
 
     requires:
-        - gcc  # [osx]
+        - gcc  # [not win]
 
     files:
         - hellow.c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,27 @@ build:
 
 requirements:
     build:
+        - toolchain
         - gcc
         - perl
+        - gcc  # [osx]
+        - libgfortran  # [linux]
     run:
-        - gcc
+        - libgfortran  # [not win]
 
 test:
+
+    requires:
+        - gcc  # [osx]
+
+    files:
+        - hellow.c
+        - hellow.f
+        - hellow.f90
+
     commands:
         - mpicc --help
-        - mpif90 --help  # [linux]
+        - mpif90 --help
 
 about:
     home: http://www.mpich.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,4 @@ extra:
         - bekozi
         - msarahan
         - ocefpaf
+        - astrofrog

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,30 @@
+# Stop on first error
+set -e
+
+# Test compilers. For this we need to set DYLD_FALLBACK_LIBRARY_PATH to
+# make sure libgfortran gets picked up. Ideally this shouldn't be needed, but
+# this is how the gfortran compiler works in conda - see:
+#
+#   https://github.com/ContinuumIO/anaconda-issues/issues/739
+#
+# for more details.
+
+export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib
+
+# Test C compiler
+echo "Testing mpicc"
+mpicc -show
+mpicc hellow.c -o hellow_c
+mpirun -n 4 ./hellow_c
+
+# Test f77 compiler
+echo "Testing mpif77"
+mpif77 -show
+mpif77 hellow.f -o hellow_f
+mpirun -n 4 ./hellow_f
+
+# Test f90 compiler
+echo "Testing mpif90"
+mpif90 -show
+mpif90 hellow.f90 -o hellow_f90
+mpirun -n 4 ./hellow_f90


### PR DESCRIPTION
I need Fortran support on MacOS X, so trying to see if there's a way to get it to work.

@bekozi @msarahan @ocefpaf - what was the reason for the fortran bindings to be disabled on MacOS X but enabled on Linux? (just so I understand)