### PR TITLE
Don't use DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$(uname)" == "Darwin" ]; then
-    export DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib
+    export LDFLAGS="-Wl,-rpath,$PREFIX/lib"
     export CC=clang
     export CXX=clang++
     export MACOSX_DEPLOYMENT_TARGET="10.9"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 0778679a6b693d7b7caff37ff9d2856dc2bfc51318bf8373859bfa74253da3dc
 
 build:
-    number: 2
+    number: 3
     skip: True  # [win]
 
 requirements:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,16 +1,6 @@
 # Stop on first error.
 set -e
 
-# Test compilers. For this we need to set DYLD_FALLBACK_LIBRARY_PATH to
-# make sure libgfortran gets picked up. Ideally this shouldn't be needed, but
-# this is how the gfortran compiler works in conda - see:
-#
-#   https://github.com/ContinuumIO/anaconda-issues/issues/739
-#
-# for more details.
-
-export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib
-
 pushd $RECIPE_DIR/tests
 
 # Test C compiler.


### PR DESCRIPTION
... because it doesn't work with recent versions of MacOS X due to the System Integrity Protection (see https://github.com/conda-forge/conda-forge.github.io/issues/238)

Note that the MPICH server seems down at the moment, so we may have to restart this.