### PR TITLE
skip mpiexec tests on Linux

### DIFF
--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -13,8 +13,15 @@ command -v mpif90
 mpif90 -show
 
 command -v mpiexec
-MPIEXEC="mpiexec -launcher fork"
-$MPIEXEC --help
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  MPIEXEC="mpiexec -launcher fork"
+  $MPIEXEC --help
+else
+  # skip mpiexec tests on Linux due to conda-forge bug:
+  # https://github.com/conda-forge/conda-smithy/pull/337
+  MPIEXEC="echo SKIPPING mpiexec"
+fi
 
 pushd $RECIPE_DIR/tests
 


### PR DESCRIPTION
due to bug in conda-smithy, which prevents upload after build

Sibling to https://github.com/conda-forge/openmpi-feedstock/pull/10

This PR should fix the bug: https://github.com/conda-forge/conda-smithy/pull/337