### PR TITLE
proposing to add 'feature' so that other libraries can be offered com…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,11 @@ source:
     url: http://www.mpich.org/static/downloads/{{ version }}/mpich-{{ version }}.tar.gz
     sha256: 0778679a6b693d7b7caff37ff9d2856dc2bfc51318bf8373859bfa74253da3dc
 
+track_features:
+    - mpich
+
 build:
-    number: 4
+    number: 5
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
…piled both against or not mpich, planning to do the same for other packages such as openmpi, so user can also choose which mpi compiler

example of libraries i would like to be able to take advantage of this "feature": "esmf", "hdf5", and "netcdf" I'm willing to do the work for these libraries.

@rokuingh @ocefpaf @bekozi @groutr @jakirkham @gillins @groutr @astrofrog @marqh @kmuehlbauer pinging you guys here as maintainer of some recipes that could take advantage of this.