### PR TITLE
fix run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
     sha256: 5db53bf2edfaa2238eb6a0a5bc3d2c2ccbfbb1badd79b664a1a919d2ce2330f1
 
 build:
-    number: 2
+    number: 3
     skip: True  # [win]
     run_exports:
-        - {{ pin_compatible('mpich', min_pin='x.x', max_pin='x.x') }}
+        - {{ pin_subpackage('mpich', min_pin='x.x', max_pin='x.x') }}
 
 requirements:
     build:
@@ -26,7 +26,9 @@ requirements:
 
 test:
     requires:
-        - gcc  # [not win]
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - {{ compiler('fortran') }}
     files:
         - tests/helloworld.c
         - tests/helloworld.cxx


### PR DESCRIPTION
pin_subpackage is the right command to get `mpich >=3.2,<3.3`. pin_compatible only gets `mpich`.