### PR TITLE
use basename for compilers

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,12 @@ if [ $(uname) == Darwin ]; then
     export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 fi
 
+# avoid absolute-paths in compilers
+export CC=$(basename "$CC")
+export CXX=$(basename "$CXX")
+export FC=$(basename "$FC")
+
+# from anaconda recipe, not sure if it matters
 export FCFLAGS="$FFLAGS"
 
 export LIBRARY_PATH="$PREFIX/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,17 @@ source:
     sha256: 5db53bf2edfaa2238eb6a0a5bc3d2c2ccbfbb1badd79b664a1a919d2ce2330f1
 
 build:
-    number: 1004
+    number: 1005
     skip: True  # [win]
     run_exports:
         - {{ pin_subpackage('mpich', min_pin='x.x', max_pin='x.x') }}
 
 requirements:
-    host:
+    build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
+    host: []
     run:
         - mpi 1.0 mpich
 


### PR DESCRIPTION
avoids downstream packages needing to put compilers in host env

Prompted by build failures in https://github.com/conda-forge/parmetis-feedstock/pull/4 due to abspath references to compiler paths when mpi is a host dep and c compiler is a build dep