### PR TITLE
rebuild without --as-needed

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,10 @@
 # with a fatal deprecation message pointing to FC
 unset F90 F77
 
+# remove --as-needed, which causes problems for downstream builds,
+# seen in failures in petsc, slepc, and hdf5 at least
+export LDFLAGS="${LDFLAGS/-Wl,--as-needed/}"
+
 if [ $(uname) == Darwin ]; then
     export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 5db53bf2edfaa2238eb6a0a5bc3d2c2ccbfbb1badd79b664a1a919d2ce2330f1
 
 build:
-    number: 1005
+    number: 1006
     skip: True  # [win]
     run_exports:
         - {{ pin_subpackage('mpich', min_pin='x.x', max_pin='x.x') }}


### PR DESCRIPTION
as-needed is recorded for downstream builds and causes failure to resolve things like libquadmath when linking fortran mpi.

The lack of as-needed was never a problem here before, so removing it shouldn't cause one now, but as-needed recorded here has caused build failures in petsc, slepc, and hdf5.