### PR TITLE
avoid embedding full cflags/ldflags in compilers

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,10 +8,6 @@ unset F90 F77
 # seen in failures in petsc, slepc, and hdf5 at least
 export LDFLAGS="${LDFLAGS/-Wl,--as-needed/}"
 
-if [ $(uname) == Darwin ]; then
-    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
-fi
-
 # avoid absolute-paths in compilers
 export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
@@ -19,6 +15,26 @@ export FC=$(basename "$FC")
 
 # from anaconda recipe, not sure if it matters
 export FCFLAGS="$FFLAGS"
+
+# avoid recording flags in compilers
+# See Compiler Flags section of MPICH readme
+export MPICHLIB_CFLAGS=$CFLAGS
+unset CFLAGS
+export MPICHLIB_CXXFLAGS=$CXXFLAGS
+unset CXXFLAGS
+export MPICHLIB_LDFLAGS=$LDFLAGS
+unset LDFLAGS
+export MPICHLIB_FFLAGS=$FFLAGS
+unset FFLAGS
+export MPICHLIB_FCFLAGS=$FCFLAGS
+unset FCFLAGS
+
+# set some specific flags that we *do* want recorded in the compilers
+# only the bare minimum of prefix-awareness here
+export CFLAGS="-I$PREFIX/include"
+export CXXFLAGS="-I$PREFIX/include"
+export FFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 
 export LIBRARY_PATH="$PREFIX/lib"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 5db53bf2edfaa2238eb6a0a5bc3d2c2ccbfbb1badd79b664a1a919d2ce2330f1
 
 build:
-    number: 1006
+    number: 1007
     skip: True  # [win]
     run_exports:
         - {{ pin_subpackage('mpich', min_pin='x.x', max_pin='x.x') }}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -14,23 +14,23 @@ mpif90 -show
 
 command -v mpiexec
 
-pushd $RECIPE_DIR/tests
+pushd tests
 
 function mpi_exec() {
   # use pipes to avoid O_NONBLOCK issues on stdin, stdout
   mpiexec -launcher fork $@ 2>&1 </dev/null | cat
 }
 
-mpicc helloworld.c -o helloworld_c
+mpicc $CFLAGS $LDFLAGS helloworld.c -o helloworld_c
 mpi_exec -n 4 ./helloworld_c
 
-mpicxx helloworld.cxx -o helloworld_cxx
+mpicxx $CXXFLAGS $LDFLAGS helloworld.cxx -o helloworld_cxx
 mpi_exec -n 4 ./helloworld_cxx
 
-mpif77 helloworld.f -o helloworld_f
+mpif77 $FFLAGS $LDFLAGS helloworld.f -o helloworld_f
 mpi_exec -n 4 ./helloworld_f
 
-mpif90 helloworld.f90 -o helloworld_f90
+mpif90 $FFLAGS $LDFLAGS helloworld.f90 -o helloworld_f90
 mpi_exec -n 4 ./helloworld_f90
 
 popd


### PR DESCRIPTION
these can get annoying and some are hard to opt-out of

instead, rely on passing cflags/ldflags at build time and only record the most basic prefix-awareness flags in the compiler defaults.

closes #29

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.