### PR TITLE
Loose run_export pin

### DIFF
--- a/.ci_support/linux_64_mpi_typeconda.yaml
+++ b/.ci_support/linux_64_mpi_typeconda.yaml
@@ -26,3 +26,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_64_mpi_typeexternal.yaml
@@ -26,3 +26,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.4" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # conda build is not making unique hashes for the different
 # fortran compiler versions
@@ -43,7 +43,7 @@ outputs:
     script: build-mpi.sh
     build:
       run_exports:
-        - {{ pin_subpackage('mpich', max_pin='x.x') }}
+        - {{ pin_subpackage('mpich', max_pin='x') }}
     requirements:
       build:
         - {{ compiler('c') }}


### PR DESCRIPTION
Utilizing ABI compatibility. cc: @isuruf @beckermr 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
