### PR TITLE
Unsupported configure option

### DIFF
--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -93,7 +93,7 @@ export FCFLAGS="$FCFLAGS -fallow-argument-mismatch"
             --disable-dependency-tracking \
             --enable-cxx \
             --enable-fortran \
-            --disable-wrapper-rpath \
+            --enable-wrapper-dl-type=none \
             --disable-opencl \
             --with-device=ch4 \
             || cat config.log

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.1.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # MPICH does not add a ".0" version suffix in initial X.Y releases
 {% set version_url = version if version[-2:] != ".0" else version[:-2] %}


### PR DESCRIPTION
The configure option `--disable-wrapper-rpath` is not available in 4.1.2. I have replaced it with `--enable-wrapper-dl-type=none`