### PR TITLE
don't install static libs

### DIFF
--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -97,6 +97,7 @@ fi
             --enable-fortran \
             --enable-f08 \
             --with-wrapper-dl-type=none \
+            --disable-static \
             --disable-opencl \
             --with-device=ch4 \
             || cat config.log

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.2.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,6 +10,9 @@ if [[ $PKG_NAME == "mpich" ]]; then
   command -v mpichversion
   mpichversion
 
+  test -f $PREFIX/lib/libmpi${SHLIB_EXT}
+  test ! -f $PREFIX/lib/libmpi.a
+
   command -v mpiexec
   $MPIEXEC -n 1 mpivars
   $MPIEXEC -n 4 ./helloworld.sh


### PR DESCRIPTION
we don't generally include these in conda-forge

I noticed this in checking install size for #100, the majority of mpich install size is static libs that shouldn't be there.