### PR TITLE
keep building with libfabric 1.19

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,27 +11,27 @@ jobs:
       linux_64_mpi_typeconda:
         CONFIG: linux_64_mpi_typeconda
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_mpi_typeexternal:
         CONFIG: linux_64_mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpi_typeconda:
         CONFIG: linux_aarch64_mpi_typeconda
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_mpi_typeexternal:
         CONFIG: linux_aarch64_mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_mpi_typeconda:
         CONFIG: linux_ppc64le_mpi_typeconda
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_mpi_typeexternal:
         CONFIG: linux_ppc64le_mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_mpi_typeconda.yaml
+++ b/.ci_support/linux_64_mpi_typeconda.yaml
@@ -17,11 +17,13 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 mpi_type:

--- a/.ci_support/linux_64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_64_mpi_typeexternal.yaml
@@ -17,11 +17,13 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 mpi_type:

--- a/.ci_support/linux_aarch64_mpi_typeconda.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeconda.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -21,11 +17,13 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 mpi_type:

--- a/.ci_support/linux_aarch64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeexternal.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -21,11 +17,13 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 mpi_type:

--- a/.ci_support/linux_ppc64le_mpi_typeconda.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeconda.yaml
@@ -17,11 +17,13 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 mpi_type:

--- a/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
@@ -17,11 +17,13 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 mpi_type:

--- a/.ci_support/osx_64_mpi_typeconda.yaml
+++ b/.ci_support/osx_64_mpi_typeconda.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 macos_machine:

--- a/.ci_support/osx_64_mpi_typeexternal.yaml
+++ b/.ci_support/osx_64_mpi_typeexternal.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 macos_machine:

--- a/.ci_support/osx_arm64_mpi_typeconda.yaml
+++ b/.ci_support/osx_arm64_mpi_typeconda.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 macos_machine:

--- a/.ci_support/osx_arm64_mpi_typeexternal.yaml
+++ b/.ci_support/osx_arm64_mpi_typeexternal.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libfabric:
+- '1.19'
 libhwloc:
 - 2.11.2
 macos_machine:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,8 @@
 mpi_type:
   - external
   - conda
+libfabric:
+  # build against libfabric 1.19
+  # for compatibility with ABI 1.6 (libfabric 1.14)
+  # this is forward-compatible with libfabric 2.x
+  - "1.19"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.2.3" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}
@@ -50,7 +50,7 @@ outputs:
         - libtool
         - gnuconfig  # [osx and arm64]
       host:
-        - libfabric
+        - libfabric-devel {{ libfabric }}.*
         - libhwloc
         - ucx  # [linux and not ppc64le]
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,11 +61,12 @@ outputs:
       files:
         - mpiexec.sh
         - tests/helloworld.sh
+      {% endif %}
       commands:
+      {% if mpi_type == 'conda' %}
         - test ! -f $PREFIX/doc/mpich
         - test ! -f $PREFIX/share/man/man3/MPI_Barrier.3
       {% else %}
-      commands:
         - echo "It works!"
       {% endif %}
 


### PR DESCRIPTION
libfabric has a stable, forward-compatible ABI.

building against libfabric 1.19 creates mpich builds that are ABI compatible with at least libfabric >=1.14 and 2.x, so this doesn't change the upper bound or default version used at runtime, but loosens the lower bound, which helps with environments using conda mpich and 'external' libfabric for hardware optimization, since HPC libfabric is often well behind.

We can target multiple libfabrics if mpich takes advantage of the API changes since 1.19, but I don't see evidence of that.