### PR TITLE
Add patch to fix issue with MPI_Comm_spawn 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.3.1" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}
@@ -15,6 +15,8 @@ source:
   fn: mpich-{{ version }}.tar.gz
   url: https://www.mpich.org/static/downloads/{{ version }}/mpich-{{ version }}.tar.gz
   sha256: acc11cb2bdc69678dc8bba747c24a28233c58596f81f03785bf2b7bb7a0ef7dc
+  patches:
+    - patches/fix-singleton-init.patch
 
 build:
   number: {{ build }}

--- a/recipe/patches/fix-singleton-init.patch
+++ b/recipe/patches/fix-singleton-init.patch
@@ -1,0 +1,24 @@
+From ef6de6ad85f24e112a6460cdefcfa0ea831c2b17 Mon Sep 17 00:00:00 2001
+From: Hui Zhou <hzhou321@anl.gov>
+Date: Thu, 1 May 2025 11:47:41 -0500
+Subject: [PATCH] hydra: fix singleton init
+
+The previous fix 7e87562555 broke the singleton init. Singleton init is
+allowed to proceed without executables in the command line.
+---
+ src/pm/hydra/mpiexec/mpiexec.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pm/hydra/mpiexec/mpiexec.c b/src/pm/hydra/mpiexec/mpiexec.c
+index 645478616be..bd38d50a30e 100644
+--- a/src/pm/hydra/mpiexec/mpiexec.c
++++ b/src/pm/hydra/mpiexec/mpiexec.c
+@@ -56,7 +56,7 @@ int main(int argc, char **argv)
+         }
+     }
+ 
+-    if (!HYD_uii_mpx_exec_list) {
++    if (!HYD_uii_mpx_exec_list && !HYD_server_info.is_singleton) {
+         HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
+                             "No executable provided. Try -h for usages.\n");
+     }


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

The newest version of mpich (4.3.1) has an issue where hydra singleton init raises an error, so MPI_Comm_spawn hangs when being called from a program not launched via `mpiexec`. This is critical functionality for the bodo package and means that we cannot upgrade our mpich dependency until the next release. 

I was wondering if it would be possible to apply this patch from [here](https://github.com/pmodels/mpich/commit/ef6de6ad85f24e112a6460cdefcfa0ea831c2b17) to fix this issue in the meantime.

Thanks!

-->
The newest version of mpich (4.3.1) has an issue where hydra singleton init raises an error, so MPI_Comm_spawn hangs when being called from a program not launched via `mpiexec`. This is critical functionality needed for the bodo package and means that we cannot upgrade our mpich dependency until the next release.

I was wondering if it would be possible to apply this patch from [here](https://github.com/pmodels/mpich/commit/ef6de6ad85f24e112a6460cdefcfa0ea831c2b17) to fix this issue in the meantime.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
